### PR TITLE
Add usegalaxy.eu badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@
         <a href="https://anaconda.org/bioconda/clipkit">
           <img src="https://img.shields.io/conda/dn/bioconda/clipkit?label=bioconda%20downloads" alt="Bioconda Downloads">
         </a>
+        <a href="https://usegalaxy.eu/root?tool_id=clipkit">
+          <img src="https://img.shields.io/badge/usegalaxy-.eu-brightgreen" alt="Run ClipKIT on the European Galaxy server">
+        </a>
         <a href="https://lbesson.mit-license.org/" alt="License">
             <img src="https://img.shields.io/badge/License-MIT-blue.svg">
         </a>


### PR DESCRIPTION
## Summary

- add a usegalaxy.eu badge to the README
- link the badge directly to ClipKIT on the European Galaxy server

## Why

This makes the Galaxy-hosted ClipKIT interface discoverable from the project README, following the badge pattern used by deepTools.

## Validation

- `git diff --check` passes
- the Shields badge URL returns successfully
- the usegalaxy.eu tool route returns successfully

No runtime code was changed.